### PR TITLE
Replace apollo-server with apollo-server-express

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,30 @@
 # graphql-api-boilerplate
-A simple GraphQL api boilerplate using Apollo Server v2 cuz I'm lazy.
+
+A complete GraphQL API using NodeJS (requires module support). It uses `apollo-server-express` and supports subscriptions
+
+## Meh I don't need subscriptions
+
+If you don't need subscriptions you can replace `index.js` with the `indexNoSubs.js` in the `alternatives` folder.
+
+## PostgreSQL alternative
+
+If you don't need PostgreSQL you can safely delete the `database` folder and removes those packages:
+
+- `npm uninstall pg pg-hstore sequelize`
+
+It uses sequelize ORM and connects to a PostgreSQL database. Also configure the needed environment variables:
+
+- `DB_HOST=myDbHost`
+- `DB_PORT=myDbPort`
+- `DB_NAME=myDbName`
+- `DB_USER=myDbUser`
+- `DB_PASSWORD=myUserPassword`
 
 ## Add .env file
-.env file to add variables to the server. `NODE_ENV=production` to disable playground and introspection.
+
+.env file to add variables to the server, they are injected to `process.env` using the `dotenv` module.
+
+- `NODE_ENV=production` to disable playground and introspection.
+- `API_PORT=yourPort` to set API port
+- `GRAPHQL_ENDPOINT='/graphql'` to set the graphQL endpoint
+- `SUBSCRIPTIONS_ENDPOINT='/subscriptions'` to set the subscriptions endpoint

--- a/database/instance.js
+++ b/database/instance.js
@@ -1,0 +1,17 @@
+import Sequelize from "sequelize";
+
+const { DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD } = process.env;
+
+const sequelize = new Sequelize(DB_NAME, DB_USER, DB_PASSWORD, {
+  host: DB_HOST,
+  dialect: "postgres",
+  port: DB_PORT,
+  pool: {
+    max: 20,
+    min: 0,
+    idle: 10000,
+  },
+  logging: process.env.NODE_ENV === "dev" ? console.log : false,
+});
+
+export default sequelize;

--- a/database/models/modelExample.js
+++ b/database/models/modelExample.js
@@ -1,0 +1,14 @@
+import { Sequelize } from "sequelize";
+import database from "../instance.js";
+
+const ExampleModel = database.define(
+  "exampleModel",
+  {
+    example: {
+      type: Sequelize.STRING,
+    },
+  },
+  { underscored: true }
+);
+
+export default ExampleModel;

--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -1,6 +1,6 @@
-const exampleResolvers = require("./resolvers/resolversExample");
-const pingResolvers = require("./resolvers/resolversPing");
+import pingResolvers from "./resolvers/resolversPing.js";
+import exampleResolvers from "./resolvers/resolversExample.js";
 
-const resolvers = [exampleResolvers, pingResolvers];
+const resolvers = [pingResolvers, exampleResolvers];
 
-module.exports = resolvers;
+export default resolvers;

--- a/graphql/resolvers/resolversPing.js
+++ b/graphql/resolvers/resolversPing.js
@@ -1,7 +1,7 @@
 const resolvers = {
   Query: {
-    ping: () => 'ping'
-  }
-}
+    ping: () => "ping",
+  },
+};
 
-module.exports = resolvers
+export default resolvers;

--- a/graphql/schemas.js
+++ b/graphql/schemas.js
@@ -1,6 +1,6 @@
-const typedefsExample = require("./schemas/schemasExample");
-const typedefsPing = require("./schemas/schemasPing");
+import pingTypedefs from "./schemas/schemasPing.js";
+import exampleTypedefs from "./schemas/schemasExample.js";
 
-const typeDefs = [typedefsExample, typedefsPing];
+const typeDefs = [pingTypedefs, exampleTypedefs];
 
-module.exports = typeDefs;
+export default typeDefs;

--- a/graphql/schemas/schemasExample.js
+++ b/graphql/schemas/schemasExample.js
@@ -1,19 +1,21 @@
-const { gql } = require('apollo-server');
-const createTempSchema = require('../utils/createTempSchema');
+import { gql } from "apollo-server-express";
+import createTempSchema from "../utils/createTempSchema.js";
 
 const exampleTypedefs = gql`
   type Query {
     ping: String
     getExamples: [String]!
+    getExamplesFromDB: [String]!
   }
   type Mutation {
-    addExemple(example: String): [String]!
+    addExample(example: String!): [String]!
+    addExampleToDB(example: String!): [String]!
   }
   type Subscription {
-    newMsg: [String]
+    newExample: [String]
   }
 `;
 
 const tempSchema = createTempSchema(exampleTypedefs);
 
-module.exports = tempSchema;
+export default tempSchema;

--- a/graphql/schemas/schemasPing.js
+++ b/graphql/schemas/schemasPing.js
@@ -1,5 +1,5 @@
-const { gql } = require('apollo-server');
-const createTempSchema = require('../utils/createTempSchema');
+import { gql } from "apollo-server-express";
+import createTempSchema from "../utils/createTempSchema.js";
 
 const typedefs = gql`
   type Query {
@@ -9,4 +9,4 @@ const typedefs = gql`
 
 const tempSchema = createTempSchema(typedefs);
 
-module.exports = tempSchema;
+export default tempSchema;

--- a/graphql/utils/createTempSchema.js
+++ b/graphql/utils/createTempSchema.js
@@ -1,12 +1,15 @@
-const { makeExecutableSchema, addMockFunctionsToSchema } = require('apollo-server');
+import {
+  makeExecutableSchema,
+  addMockFunctionsToSchema,
+} from "apollo-server-express";
 
 const createTempSchema = (typdefs) => {
   const tempSchema = makeExecutableSchema({
-    typeDefs: [typdefs]
+    typeDefs: [typdefs],
   });
   addMockFunctionsToSchema({ schema: tempSchema });
 
   return tempSchema;
-}
+};
 
-module.exports = createTempSchema;
+export default createTempSchema;

--- a/graphql/utils/dotenv.js
+++ b/graphql/utils/dotenv.js
@@ -1,0 +1,5 @@
+import dotenv from "dotenv";
+
+// Since we are use ES6 import dotenv must be imported before everything else
+// Add environment variables to process.env
+dotenv.config({ path: ".env" });

--- a/graphql/utils/pubsub.js
+++ b/graphql/utils/pubsub.js
@@ -1,5 +1,5 @@
-const { PubSub } = require('apollo-server');
+import { PubSub } from "apollo-server-express";
 
 const pubsub = new PubSub();
 
-module.exports = pubsub;
+export default pubsub;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,19 +8,22 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "apollo-server": "^2.22.2",
+        "apollo-server-express": "^2.23.0",
         "dotenv": "^8.2.0",
+        "express": "^4.17.1",
         "graphql": "^15.5.0",
-        "graphql-tools": "^4.0.8"
+        "pg": "^8.6.0",
+        "pg-hstore": "^2.3.3",
+        "sequelize": "^6.6.2"
       },
       "devDependencies": {
         "nodemon": "^2.0.7"
       }
     },
     "node_modules/@apollo/protobufjs": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.5.tgz",
-      "integrity": "sha512-ZtyaBH1icCgqwIGb3zrtopV2D5Q8yxibkJzlaViM08eOhTQc7rACdYu0pfORFfhllvdMZ3aq69vifYHszY4gNA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.0.tgz",
+      "integrity": "sha512-TBgsADig/K4Hx71uQO6KPLxgoE/ORhPGh/HgouHru+cum8RLDfAfEY5Dde+cNala+luGI2X4Rs42pLWRud7/WA==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -43,16 +46,16 @@
       }
     },
     "node_modules/@apollo/protobufjs/node_modules/@types/node": {
-      "version": "10.17.56",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
-      "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+      "version": "10.17.58",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.58.tgz",
+      "integrity": "sha512-Dn5RBxLohjdHFj17dVVw3rtrZAeXeWg+LQfvxDIW/fdPkSiuQk7h3frKMYtsQhtIW42wkErDcy9UMVxhGW4O7w=="
     },
     "node_modules/@apollographql/apollo-tools": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.9.tgz",
-      "integrity": "sha512-M50pk8oo3CGTu4waGOklIX3YtTZoPfWG9K/G9WB8NpyQGA1OwYTiBFv94XqUtKElTDoFwoMXpMQd3Wy5dINvxA==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.12.tgz",
+      "integrity": "sha512-JdC7aBzMUO6SaGH5g6MvIG8TWd+7cU/G9cyjKS/woYVtqyICLamyG21R8SmjiBnd5c1UgPWOxjSIxYBL2ln8Mg==",
       "dependencies": {
-        "apollo-env": "^0.6.6"
+        "apollo-env": "^0.9.0"
       },
       "engines": {
         "node": ">=8",
@@ -209,12 +212,9 @@
       }
     },
     "node_modules/@types/cors": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.8.tgz",
-      "integrity": "sha512-fO3gf3DxU2Trcbr75O7obVndW/X5k8rJNZkLXlQWStTHhP71PkRqjwPIEI0yMnJdg9R9OasjU+Bsr+Hr1xy/0w==",
-      "dependencies": {
-        "@types/express": "*"
-      }
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
+      "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ=="
     },
     "node_modules/@types/express": {
       "version": "4.17.11",
@@ -294,14 +294,14 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "node_modules/@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
+      "version": "14.14.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -443,6 +443,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -484,11 +489,11 @@
       }
     },
     "node_modules/apollo-env": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.6.tgz",
-      "integrity": "sha512-hXI9PjJtzmD34XviBU+4sPMOxnifYrHVmxpjykqI/dUD2G3yTiuRaiQqwRwB2RCdwC1Ug/jBfoQ/NHDTnnjndQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.9.0.tgz",
+      "integrity": "sha512-oMSaFiCYEULXTv1sLhuPpAg0SykJNzEu5QWvCw0844yq14MyETXFERmAYD9b8nNjQLAdpjbbkBGKTWcw5wgd5Q==",
       "dependencies": {
-        "@types/node-fetch": "2.5.7",
+        "@types/node-fetch": "2.5.8",
         "core-js": "^3.0.1",
         "node-fetch": "^2.2.0",
         "sha.js": "^2.4.11"
@@ -510,6 +515,29 @@
       },
       "peerDependencies": {
         "graphql": "^14.2.1 || ^15.0.0"
+      }
+    },
+    "node_modules/apollo-graphql/node_modules/@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/apollo-graphql/node_modules/apollo-env": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.6.tgz",
+      "integrity": "sha512-hXI9PjJtzmD34XviBU+4sPMOxnifYrHVmxpjykqI/dUD2G3yTiuRaiQqwRwB2RCdwC1Ug/jBfoQ/NHDTnnjndQ==",
+      "dependencies": {
+        "@types/node-fetch": "2.5.7",
+        "core-js": "^3.0.1",
+        "node-fetch": "^2.2.0",
+        "sha.js": "^2.4.11"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/apollo-link": {
@@ -534,22 +562,6 @@
         "@apollo/protobufjs": "^1.0.3"
       }
     },
-    "node_modules/apollo-server": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.22.2.tgz",
-      "integrity": "sha512-Lt+7FxqweSMg2cn5HXksEhdZj1lOojJ+5RMNKys0hkKp9xP/qwHW7+NrFTcItRstHPz27filleAHjoziaWdpiA==",
-      "dependencies": {
-        "apollo-server-core": "^2.22.2",
-        "apollo-server-express": "^2.22.2",
-        "express": "^4.0.0",
-        "graphql-subscriptions": "^1.0.0",
-        "graphql-tools": "^4.0.8",
-        "stoppable": "^1.1.0"
-      },
-      "peerDependencies": {
-        "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
-      }
-    },
     "node_modules/apollo-server-caching": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.6.0.tgz",
@@ -562,9 +574,9 @@
       }
     },
     "node_modules/apollo-server-core": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.22.2.tgz",
-      "integrity": "sha512-YPrhfN+I5vUerc4c0I6pd89fdqP5UNYCt/+MGv4bDA/a0kOCLvzylkQ3NlEepK1fewtqf4QO+S1LscC8vMmYdg==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.23.0.tgz",
+      "integrity": "sha512-3/a4LPgRADc8CdT/nRh7W0CAqQv3Q4DJvakWQgKqGSqDEb/0u4IBynYjlQKuPBi4wwKdeK2Hb1wiQLl+zu4StQ==",
       "dependencies": {
         "@apollographql/apollo-tools": "^0.4.3",
         "@apollographql/graphql-playground-html": "1.6.27",
@@ -577,7 +589,7 @@
         "apollo-reporting-protobuf": "^0.6.2",
         "apollo-server-caching": "^0.6.0",
         "apollo-server-env": "^3.0.0",
-        "apollo-server-errors": "^2.4.2",
+        "apollo-server-errors": "^2.5.0",
         "apollo-server-plugin-base": "^0.11.0",
         "apollo-server-types": "^0.7.0",
         "apollo-tracing": "^0.13.0",
@@ -613,9 +625,9 @@
       }
     },
     "node_modules/apollo-server-errors": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz",
-      "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz",
+      "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA==",
       "engines": {
         "node": ">=6"
       },
@@ -624,21 +636,21 @@
       }
     },
     "node_modules/apollo-server-express": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.22.2.tgz",
-      "integrity": "sha512-MRiWF/oT6toUz909iq1I08vKfRxaqRMKS/v9kzyEXcnuudUCQ5WnxrjZEh/iMEfr7RHSQ4STjY7E/ZooPnueqA==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.23.0.tgz",
+      "integrity": "sha512-tzil7c51ODH0rT1Bc5VMksdWzHrYGavdLtnDz4M0ePiTm18Gc81HD7X/4DPczorerEpfwwkf2YlADtPQfRSxlw==",
       "dependencies": {
         "@apollographql/graphql-playground-html": "1.6.27",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.0",
-        "@types/cors": "2.8.8",
+        "@types/cors": "2.8.10",
         "@types/express": "4.17.11",
         "@types/express-serve-static-core": "4.17.19",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.22.2",
+        "apollo-server-core": "^2.23.0",
         "apollo-server-types": "^0.7.0",
         "body-parser": "^1.18.3",
-        "cors": "^2.8.4",
+        "cors": "^2.8.5",
         "express": "^4.17.1",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.8",
@@ -837,6 +849,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/busboy": {
@@ -1093,9 +1113,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/core-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
-      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.0.tgz",
+      "integrity": "sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -1230,6 +1250,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dottie": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
+      "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
     },
     "node_modules/duplexer3": {
       "version": "0.1.4",
@@ -1730,6 +1755,14 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inflection": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
+      "engines": [
+        "node >= 0.4.0"
+      ]
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2005,6 +2038,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -2149,6 +2187,25 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.33",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2256,9 +2313,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2365,6 +2422,11 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2378,6 +2440,91 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "node_modules/pg": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
+      "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.3.0",
+        "pg-protocol": "^1.5.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "node_modules/pg-hstore": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/pg-hstore/-/pg-hstore-2.3.3.tgz",
+      "integrity": "sha512-qpeTpdkguFgfdoidtfeTho1Q1zPVPbtMHgs8eQ+Aan05iLmIs3Z3oo5DOZRclPGoQ4i68I1kCtQSJSa7i0ZVYg==",
+      "dependencies": {
+        "underscore": "^1.7.0"
+      },
+      "engines": {
+        "node": ">= 0.8.x"
+      }
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
+      "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
+      "dependencies": {
+        "split2": "^3.1.1"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -2388,6 +2535,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prepend-http": {
@@ -2504,6 +2686,19 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
@@ -2555,6 +2750,14 @@
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/retry-as-promised": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
+      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
+      "dependencies": {
+        "any-promise": "^1.3.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -2640,6 +2843,92 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
+    "node_modules/sequelize": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.6.2.tgz",
+      "integrity": "sha512-H/zrzmTK+tis9PJaSigkuXI57nKBvNCtPQol0yxCvau1iWLzSOuq8t3tMOVeQ+Ep8QH2HoD9/+FCCIAqzUr/BQ==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "dottie": "^2.0.0",
+        "inflection": "1.12.0",
+        "lodash": "^4.17.20",
+        "moment": "^2.26.0",
+        "moment-timezone": "^0.5.31",
+        "retry-as-promised": "^3.2.0",
+        "semver": "^7.3.2",
+        "sequelize-pool": "^6.0.0",
+        "toposort-class": "^1.0.1",
+        "uuid": "^8.1.0",
+        "validator": "^10.11.0",
+        "wkx": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mariadb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-hstore": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sequelize-pool": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-6.1.0.tgz",
+      "integrity": "sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/sequelize/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sequelize/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/sequelize/node_modules/semver": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
@@ -2677,21 +2966,20 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-      "engines": {
-        "node": ">=4",
-        "npm": ">=6"
       }
     },
     "node_modules/streamsearch": {
@@ -2701,6 +2989,33 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/string-width": {
       "version": "4.2.2",
@@ -2845,6 +3160,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toposort-class": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
+    },
     "node_modules/touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -2923,6 +3243,11 @@
         "debug": "^2.2.0"
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -2982,6 +3307,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "node_modules/util.promisify": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.1.tgz",
@@ -3011,6 +3341,14 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validator": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {
@@ -3046,6 +3384,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wkx": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/wrappy": {
@@ -3098,6 +3444,14 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -3120,9 +3474,9 @@
   },
   "dependencies": {
     "@apollo/protobufjs": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.0.5.tgz",
-      "integrity": "sha512-ZtyaBH1icCgqwIGb3zrtopV2D5Q8yxibkJzlaViM08eOhTQc7rACdYu0pfORFfhllvdMZ3aq69vifYHszY4gNA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@apollo/protobufjs/-/protobufjs-1.2.0.tgz",
+      "integrity": "sha512-TBgsADig/K4Hx71uQO6KPLxgoE/ORhPGh/HgouHru+cum8RLDfAfEY5Dde+cNala+luGI2X4Rs42pLWRud7/WA==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -3140,18 +3494,18 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.56",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.56.tgz",
-          "integrity": "sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w=="
+          "version": "10.17.58",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.58.tgz",
+          "integrity": "sha512-Dn5RBxLohjdHFj17dVVw3rtrZAeXeWg+LQfvxDIW/fdPkSiuQk7h3frKMYtsQhtIW42wkErDcy9UMVxhGW4O7w=="
         }
       }
     },
     "@apollographql/apollo-tools": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.9.tgz",
-      "integrity": "sha512-M50pk8oo3CGTu4waGOklIX3YtTZoPfWG9K/G9WB8NpyQGA1OwYTiBFv94XqUtKElTDoFwoMXpMQd3Wy5dINvxA==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/@apollographql/apollo-tools/-/apollo-tools-0.4.12.tgz",
+      "integrity": "sha512-JdC7aBzMUO6SaGH5g6MvIG8TWd+7cU/G9cyjKS/woYVtqyICLamyG21R8SmjiBnd5c1UgPWOxjSIxYBL2ln8Mg==",
       "requires": {
-        "apollo-env": "^0.6.6"
+        "apollo-env": "^0.9.0"
       }
     },
     "@apollographql/graphql-playground-html": {
@@ -3292,12 +3646,9 @@
       }
     },
     "@types/cors": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.8.tgz",
-      "integrity": "sha512-fO3gf3DxU2Trcbr75O7obVndW/X5k8rJNZkLXlQWStTHhP71PkRqjwPIEI0yMnJdg9R9OasjU+Bsr+Hr1xy/0w==",
-      "requires": {
-        "@types/express": "*"
-      }
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
+      "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ=="
     },
     "@types/express": {
       "version": "4.17.11",
@@ -3377,14 +3728,14 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
+      "version": "14.14.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g=="
     },
     "@types/node-fetch": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -3504,6 +3855,11 @@
         "color-convert": "^2.0.1"
       }
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -3533,11 +3889,11 @@
       }
     },
     "apollo-env": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.6.tgz",
-      "integrity": "sha512-hXI9PjJtzmD34XviBU+4sPMOxnifYrHVmxpjykqI/dUD2G3yTiuRaiQqwRwB2RCdwC1Ug/jBfoQ/NHDTnnjndQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.9.0.tgz",
+      "integrity": "sha512-oMSaFiCYEULXTv1sLhuPpAg0SykJNzEu5QWvCw0844yq14MyETXFERmAYD9b8nNjQLAdpjbbkBGKTWcw5wgd5Q==",
       "requires": {
-        "@types/node-fetch": "2.5.7",
+        "@types/node-fetch": "2.5.8",
         "core-js": "^3.0.1",
         "node-fetch": "^2.2.0",
         "sha.js": "^2.4.11"
@@ -3550,6 +3906,28 @@
       "requires": {
         "apollo-env": "^0.6.6",
         "lodash.sortby": "^4.7.0"
+      },
+      "dependencies": {
+        "@types/node-fetch": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+          "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+          "requires": {
+            "@types/node": "*",
+            "form-data": "^3.0.0"
+          }
+        },
+        "apollo-env": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.6.6.tgz",
+          "integrity": "sha512-hXI9PjJtzmD34XviBU+4sPMOxnifYrHVmxpjykqI/dUD2G3yTiuRaiQqwRwB2RCdwC1Ug/jBfoQ/NHDTnnjndQ==",
+          "requires": {
+            "@types/node-fetch": "2.5.7",
+            "core-js": "^3.0.1",
+            "node-fetch": "^2.2.0",
+            "sha.js": "^2.4.11"
+          }
+        }
       }
     },
     "apollo-link": {
@@ -3571,19 +3949,6 @@
         "@apollo/protobufjs": "^1.0.3"
       }
     },
-    "apollo-server": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.22.2.tgz",
-      "integrity": "sha512-Lt+7FxqweSMg2cn5HXksEhdZj1lOojJ+5RMNKys0hkKp9xP/qwHW7+NrFTcItRstHPz27filleAHjoziaWdpiA==",
-      "requires": {
-        "apollo-server-core": "^2.22.2",
-        "apollo-server-express": "^2.22.2",
-        "express": "^4.0.0",
-        "graphql-subscriptions": "^1.0.0",
-        "graphql-tools": "^4.0.8",
-        "stoppable": "^1.1.0"
-      }
-    },
     "apollo-server-caching": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.6.0.tgz",
@@ -3593,9 +3958,9 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.22.2.tgz",
-      "integrity": "sha512-YPrhfN+I5vUerc4c0I6pd89fdqP5UNYCt/+MGv4bDA/a0kOCLvzylkQ3NlEepK1fewtqf4QO+S1LscC8vMmYdg==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.23.0.tgz",
+      "integrity": "sha512-3/a4LPgRADc8CdT/nRh7W0CAqQv3Q4DJvakWQgKqGSqDEb/0u4IBynYjlQKuPBi4wwKdeK2Hb1wiQLl+zu4StQ==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.3",
         "@apollographql/graphql-playground-html": "1.6.27",
@@ -3608,7 +3973,7 @@
         "apollo-reporting-protobuf": "^0.6.2",
         "apollo-server-caching": "^0.6.0",
         "apollo-server-env": "^3.0.0",
-        "apollo-server-errors": "^2.4.2",
+        "apollo-server-errors": "^2.5.0",
         "apollo-server-plugin-base": "^0.11.0",
         "apollo-server-types": "^0.7.0",
         "apollo-tracing": "^0.13.0",
@@ -3635,27 +4000,27 @@
       }
     },
     "apollo-server-errors": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz",
-      "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz",
+      "integrity": "sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA==",
       "requires": {}
     },
     "apollo-server-express": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.22.2.tgz",
-      "integrity": "sha512-MRiWF/oT6toUz909iq1I08vKfRxaqRMKS/v9kzyEXcnuudUCQ5WnxrjZEh/iMEfr7RHSQ4STjY7E/ZooPnueqA==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.23.0.tgz",
+      "integrity": "sha512-tzil7c51ODH0rT1Bc5VMksdWzHrYGavdLtnDz4M0ePiTm18Gc81HD7X/4DPczorerEpfwwkf2YlADtPQfRSxlw==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.27",
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.19.0",
-        "@types/cors": "2.8.8",
+        "@types/cors": "2.8.10",
         "@types/express": "4.17.11",
         "@types/express-serve-static-core": "4.17.19",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.22.2",
+        "apollo-server-core": "^2.23.0",
         "apollo-server-types": "^0.7.0",
         "body-parser": "^1.18.3",
-        "cors": "^2.8.4",
+        "cors": "^2.8.5",
         "express": "^4.17.1",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.8",
@@ -3812,6 +4177,11 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "busboy": {
       "version": "0.3.1",
@@ -4009,9 +4379,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
-      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ=="
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.0.tgz",
+      "integrity": "sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw=="
     },
     "cors": {
       "version": "2.8.5",
@@ -4111,6 +4481,11 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
+    "dottie": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
+      "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -4498,6 +4873,11 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "inflection": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+      "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY="
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -4683,6 +5063,11 @@
         "package-json": "^6.3.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -4783,6 +5168,19 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
+    "moment-timezone": {
+      "version": "0.5.33",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4860,9 +5258,9 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -4938,6 +5336,11 @@
         }
       }
     },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4948,11 +5351,97 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "pg": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.6.0.tgz",
+      "integrity": "sha512-qNS9u61lqljTDFvmk/N66EeGq3n6Ujzj0FFyNMGQr6XuEv4tgNTXvJQTfJdcvGit5p5/DWPu+wj920hAJFI+QQ==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.5.0",
+        "pg-pool": "^3.3.0",
+        "pg-protocol": "^1.5.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      }
+    },
+    "pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+    },
+    "pg-hstore": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/pg-hstore/-/pg-hstore-2.3.3.tgz",
+      "integrity": "sha512-qpeTpdkguFgfdoidtfeTho1Q1zPVPbtMHgs8eQ+Aan05iLmIs3Z3oo5DOZRclPGoQ4i68I1kCtQSJSa7i0ZVYg==",
+      "requires": {
+        "underscore": "^1.7.0"
+      }
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-pool": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.3.0.tgz",
+      "integrity": "sha512-0O5huCql8/D6PIRFAlmccjphLYWC+JIzvUhSzXSpGaf+tjTZc4nn+Lr7mLXBbFJfvwbP0ywDv73EiaBsxn7zdg==",
+      "requires": {}
+    },
+    "pg-protocol": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
+      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.4.tgz",
+      "integrity": "sha512-YmuA56alyBq7M59vxVBfPJrGSozru8QAdoNlWuW3cz8l+UX3cWge0vTvjKhsSHSJpo3Bom8/Mm6hf0TR5GY0+w==",
+      "requires": {
+        "split2": "^3.1.1"
+      }
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+    },
+    "postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -5046,6 +5535,16 @@
         "strip-json-comments": "~2.0.1"
       }
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "readdirp": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
@@ -5086,6 +5585,14 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
+    },
+    "retry-as-promised": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-3.2.0.tgz",
+      "integrity": "sha512-CybGs60B7oYU/qSQ6kuaFmRd9sTZ6oXSc0toqePvV74Ac6/IFZSI1ReFQmtCN+uvW1Mtqdwpvt/LGOiCBAY2Mg==",
+      "requires": {
+        "any-promise": "^1.3.0"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -5159,6 +5666,54 @@
         }
       }
     },
+    "sequelize": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.6.2.tgz",
+      "integrity": "sha512-H/zrzmTK+tis9PJaSigkuXI57nKBvNCtPQol0yxCvau1iWLzSOuq8t3tMOVeQ+Ep8QH2HoD9/+FCCIAqzUr/BQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "dottie": "^2.0.0",
+        "inflection": "1.12.0",
+        "lodash": "^4.17.20",
+        "moment": "^2.26.0",
+        "moment-timezone": "^0.5.31",
+        "retry-as-promised": "^3.2.0",
+        "semver": "^7.3.2",
+        "sequelize-pool": "^6.0.0",
+        "toposort-class": "^1.0.1",
+        "uuid": "^8.1.0",
+        "validator": "^10.11.0",
+        "wkx": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "sequelize-pool": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-6.1.0.tgz",
+      "integrity": "sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg=="
+    },
     "serve-static": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
@@ -5190,20 +5745,38 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "requires": {
+        "readable-stream": "^3.0.0"
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
-    "stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="
-    },
     "streamsearch": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
     },
     "string-width": {
       "version": "4.2.2",
@@ -5311,6 +5884,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
+    "toposort-class": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha1-f/0feMi+KMO6Rc1OGj9e4ZO9mYg="
+    },
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -5377,6 +5955,11 @@
         "debug": "^2.2.0"
       }
     },
+    "underscore": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+    },
     "unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -5421,6 +6004,11 @@
         "prepend-http": "^2.0.0"
       }
     },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "util.promisify": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.1.tgz",
@@ -5442,6 +6030,11 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "validator": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
     },
     "vary": {
       "version": "1.1.2",
@@ -5467,6 +6060,14 @@
       "dev": true,
       "requires": {
         "string-width": "^4.0.0"
+      }
+    },
+    "wkx": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "wrappy": {
@@ -5509,6 +6110,11 @@
         "commander": "^2.20.3",
         "cssfilter": "0.0.10"
       }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node index.js",
     "dev": "nodemon index.js"
   },
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/FrostiizGit/graphql-api-boilerplate.git"
@@ -18,10 +19,13 @@
   },
   "homepage": "https://github.com/FrostiizGit/graphql-api-boilerplate#readme",
   "dependencies": {
-    "apollo-server": "^2.22.2",
+    "apollo-server-express": "^2.23.0",
     "dotenv": "^8.2.0",
+    "express": "^4.17.1",
     "graphql": "^15.5.0",
-    "graphql-tools": "^4.0.8"
+    "pg": "^8.6.0",
+    "pg-hstore": "^2.3.3",
+    "sequelize": "^6.6.2"
   },
   "devDependencies": {
     "nodemon": "^2.0.7"


### PR DESCRIPTION
Replaced apollo-server v2 with apollo-server-express to be able to use middlewares. 
Also improved the readme and added a database instance to the examples.
Also switch to ES6 because it was time to do it.